### PR TITLE
Add virtual environment setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ options:
 ### Python Analysis Package
 
 The `picnix` Python package provides data analysis tools for simulation output.
-Install it as an editable package with `uv`:
+It is recommended to install it inside a virtual environment:
+
+```sh
+# Create and activate a virtual environment
+uv venv .venv
+source .venv/bin/activate
+```
+
+Then install the package:
 
 ```sh
 # From the repository root


### PR DESCRIPTION
## Summary
- Add `uv venv` setup instructions back to the Python Analysis Package section in README.md, which were accidentally removed during the package migration in #17.

## Why
Users need guidance on creating a virtual environment before installing the package.